### PR TITLE
refactor: Add cmi-dev-db service to docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -75,7 +75,31 @@ services:
       interval: 30s
       timeout: 10s
       retries: 5
+  cmi-dev-db:
+    image: mysql:5.7
+    restart: always
+    container_name: ecmi-cmidb
+    ports:
+      - 3306:3306
+    environment:
+      MYSQL_ROOT_PASSWORD: rootpassword
+      MYSQL_DATABASE: cmi_dev_db
+      MYSQL_USER: cmi
+      MYSQL_PASSWORD: cmi_password
+    volumes:
+      - ./data/department.sql:/docker-entrypoint-initdb.d/department.sql
+      - ./data/research.sql:/docker-entrypoint-initdb.d/research.sql
+    healthcheck:
+      test:
+        [
+          "CMD-SHELL",
+          'mysqladmin ping -h localhost -u $$MYSQL_USER --password=$$MYSQL_PASSWORD && mysql -u $$MYSQL_USER --password=$$MYSQL_PASSWORD -e ''SHOW DATABASES LIKE "$$MYSQL_DATABASE";''',
+        ]
+      interval: 30s
+      timeout: 10s
+      retries: 5
 volumes:
   ghost:
   ghost-db:
   cmi-db:
+  cmi-dev-db:


### PR DESCRIPTION
This commit adds the `cmi-dev-db` service to the `docker-compose.yml` file. The service uses the `mysql:5.7` image and is configured with the necessary environment variables and volumes for the `cmi_dev_db` database. This addition allows for the setup of a development database for the application.